### PR TITLE
New API to start the crashpad handler without creating a sentry session (offline reporting)

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -2058,6 +2058,23 @@ SENTRY_EXPERIMENTAL_API const char *sentry_sdk_name(void);
  */
 SENTRY_EXPERIMENTAL_API const char *sentry_sdk_user_agent(void);
 
+#ifdef SENTRY_PLATFORM_WINDOWS
+typedef void (*CrashpadExceptionHandledCallback)(EXCEPTION_POINTERS *exceptionInfo);
+
+/**
+ * Starts the crashpad handler when not using sentry for error reporting.
+ * Do not call this function with sentry_init().
+ * Returns 0 on success, 1 on error.
+ *
+ * This function should only be called once per process.
+ * This function is not thread safe.
+ */
+SENTRY_EXPERIMENTAL_API int crashpad_start_handler(const char *productName,
+    const char *productVersion, const char *handlerFilePath,
+    const char *databaseDirectoryPath,
+    CrashpadExceptionHandledCallback callback);
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
# Justification

For offline error reporting, I want to be able to start the crashpad handler to generate a minidump when a crash such as access violation occurs.

# Implementation

Add a new API on Windows to start the crashpad handler without creating a sentry session.

The new function is declared in `sentry.h` and implemented in `src/backends/sentry_backend_crashpad.cpp`

```
#ifdef SENTRY_PLATFORM_WINDOWS
/**
 * Starts the crashpad handler at handlerFilePath.
 * Returns 0 on success, 1 on error.
 */
SENTRY_EXPERIMENTAL_API int crashpad_start_handler(const char *productName,
    const char *productVersion, const char *handlerFilePath,
    const char *databaseDirectoryPath);
#endif
```
